### PR TITLE
Fix for patmch_v1.py for shedskin

### DIFF
--- a/patmch/patmch_v1.py
+++ b/patmch/patmch_v1.py
@@ -6,7 +6,9 @@ if (len(sys.argv) < 2):
 
 # the following is not correct. we have to trim off the tailing '\n'
 
-r = re.compile(sys.argv[1])
+repattern = sys.argv[1][:-1] if sys.argv[1][-1]=='\n' else sys.argv[1]
+r = re.compile(repattern)
 for line in sys.stdin:
-    if r.search(line[0:-1]):
-		sys.stdout.write(line)
+    line = line[:-1]
+    if line and r.search(line):
+        sys.stdout.write(line)


### PR DESCRIPTION
Shedskin's slightly different regex implementation errors out when the r.search() input is an empty string, so this just makes sure such a search never happens.

Also, Shedskin 0.8 doesn't strip the newline off the last sys.argv so it also takes it off if it's still there. It's a one-time cost and will still work when SS is updated to fix it.
