### PR TITLE
Restore python 3 compatibility

### DIFF
--- a/sudoku/sudoku_v1.py
+++ b/sudoku/sudoku_v1.py
@@ -1,5 +1,10 @@
 import sys, string
 
+try:
+	xrange(1)
+except NameError:
+	xrange = range
+
 def sd_genmat():
 	r, C = 0, []
 	for i in xrange(9):


### PR DESCRIPTION
Given the style of print used it looks like the python sudoku solver was written to run under both python 2 and 3. The recent change to use xrange while the right thing to do for python 2, breaks the compatibility with python 3. Fortunately this can be easily repaired without affecting the speed.
