### PR TITLE
Update patmch_v1.d

### DIFF
--- a/patmch/patmch_v1.d
+++ b/patmch/patmch_v1.d
@@ -1,17 +1,18 @@
 // This program segfaults on simple input and complains "Error: std.format"
 // given the "howto" file, even if I clean the text.
 
-import std.stdio, std.regexp;
+import std.stdio, std.regex;
 
 int main(string[] args) {
 	if (args.length < 2) {
 		writefln("Usage: patmatch pattern < in.file");
 		return 1;
 	}
-	char[] buf;
-	auto re = RegExp(args[1]);
-	while ((buf = readln()) != null)
-		if (re.find(buf[0 .. buf.length-1]) > 0)
-			writef(buf);
+	
+	auto re = regex(args[1]);
+	foreach(line; stdin.byLine) {
+		foreach(c; matchAll(line, re)) writeln(c.hit);
+	}
+	
 	return 0;
 }


### PR DESCRIPTION
Rewritten to give D a strong chance at the benchmark.
Unfortunately, there are some limitations to the D regex regarding encoding (As you found). https://dlang.org/phobos/std_regex.html#Unicode%20support

You can clean the howto file with 
`iconv -f iso-8859-1 -t utf-8 howto > howto2`

Line 12 can be rewritten with a compile-time generated Regex engine,
`auto re = ctRegex!(r"([a-zA-Z][a-zA-Z0-9]*)://([^ /]+)(/?[^ ]*)");`
if you feel it fair to sacrifice the command-line pattern option.